### PR TITLE
Alternative backwards-compatible headers for react-native 0.40.0+ support

### DIFF
--- a/RNBeacon.h
+++ b/RNBeacon.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Geniux Consulting. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNBeacon : NSObject <RCTBridgeModule>
 

--- a/RNBeacon.h
+++ b/RNBeacon.h
@@ -6,7 +6,15 @@
 //  Copyright (c) 2015 Geniux Consulting. All rights reserved.
 //
 
+#if __has_include(<React/RCTBridgeModule.h>)
+
 #import <React/RCTBridgeModule.h>
+
+#else
+
+#import "RCTBridgeModule.h"
+
+#endif
 
 @interface RNBeacon : NSObject <RCTBridgeModule>
 

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -8,9 +8,19 @@
 
 #import <CoreLocation/CoreLocation.h>
 
+#if __has_include(<React/RCTBridge.h>)
+
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
+
+#else
+
+#import "RCTBridge.h"
+#import "RCTConvert.h"
+#import "RCTEventDispatcher.h"
+
+#endif
 
 #import "RNBeacon.h"
 

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -8,9 +8,9 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "RNBeacon.h"
 


### PR DESCRIPTION
This is an alternative approach to import the changed headers of react-native 0.40.0+

I recommend the other approach from #43, but you can choose either PR for this purpose.