### PR TITLE
Add check if proximityUUID exists

### DIFF
--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -232,6 +232,10 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 
 -(void)locationManager:(CLLocationManager *)manager
         didEnterRegion:(CLBeaconRegion *)region {
+    if (! [region respondsToSelector:@selector(proximityUUID)]) {
+        return;
+    }
+
     NSDictionary *event = @{
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
@@ -242,6 +246,10 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 
 -(void)locationManager:(CLLocationManager *)manager
          didExitRegion:(CLBeaconRegion *)region {
+    if (! [region respondsToSelector:@selector(proximityUUID)]) {
+        return;
+    }
+
     NSDictionary *event = @{
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],


### PR DESCRIPTION
Using the `react-native-ibeacon` together with the `react-native-background-geolocation` throws an error described in #35. This PR simply implements the commented solution.
The changes were tested with existing beacons, no errors or unwanted behaviour was observed.