### PR TITLE
Fix duplicate interface definition RTBridge

### DIFF
--- a/RNBeacon.h
+++ b/RNBeacon.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Geniux Consulting. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNBeacon : NSObject <RCTBridgeModule>
 

--- a/RNBeacon.h
+++ b/RNBeacon.h
@@ -7,7 +7,8 @@
 //
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RNBeacon : NSObject <RCTBridgeModule>
+@interface RNBeacon : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -8,7 +8,7 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import "RCTBridge.h"
+//#import "RCTBridge.h"
 #import "RCTConvert.h"
 #import "RCTEventDispatcher.h"
 

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -33,12 +33,12 @@ RCT_EXPORT_MODULE()
 {
     if (self = [super init]) {
         self.locationManager = [[CLLocationManager alloc] init];
-        
+
         self.locationManager.delegate = self;
         self.locationManager.pausesLocationUpdatesAutomatically = NO;
         self.dropEmptyRanges = NO;
     }
-    
+
     return self;
 }
 
@@ -47,38 +47,38 @@ RCT_EXPORT_MODULE()
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major minor:(NSInteger) minor
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     unsigned short mj = (unsigned short) major;
     unsigned short mi = (unsigned short) minor;
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj minor:mi identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     unsigned short mj = (unsigned short) major;
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
@@ -147,6 +147,9 @@ RCT_EXPORT_METHOD(stopRangingBeaconsInRegion:(NSDictionary *) dict)
 
 RCT_EXPORT_METHOD(startUpdatingLocation)
 {
+    if ([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
+        [_locationManager setAllowsBackgroundLocationUpdates:YES];
+    }
     [self.locationManager startUpdatingLocation];
 }
 
@@ -187,7 +190,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 }
 
 - (void)locationManager:(CLLocationManager *)manager rangingBeaconsDidFailForRegion:(CLBeaconRegion *)region withError:(NSError *)error
-{    
+{
     NSLog(@"Failed ranging region: %@", error);
 }
 
@@ -206,19 +209,19 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
         return;
     }
     NSMutableArray *beaconArray = [[NSMutableArray alloc] init];
-    
+
     for (CLBeacon *beacon in beacons) {
         [beaconArray addObject:@{
                                  @"uuid": [beacon.proximityUUID UUIDString],
                                  @"major": beacon.major,
                                  @"minor": beacon.minor,
-                                 
+
                                  @"rssi": [NSNumber numberWithLong:beacon.rssi],
                                  @"proximity": [self stringForProximity: beacon.proximity],
                                  @"accuracy": [NSNumber numberWithDouble: beacon.accuracy]
                                  }];
     }
-    
+
     NSDictionary *event = @{
                             @"region": @{
                                     @"identifier": region.identifier,
@@ -226,7 +229,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                                     },
                             @"beacons": beaconArray
                             };
-    
+
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"beaconsDidRange" body:event];
 }
 
@@ -236,7 +239,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-    
+
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidEnter" body:event];
 }
 
@@ -246,7 +249,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-    
+
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidExit" body:event];
 }
 

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -33,12 +33,12 @@ RCT_EXPORT_MODULE()
 {
     if (self = [super init]) {
         self.locationManager = [[CLLocationManager alloc] init];
-
+        
         self.locationManager.delegate = self;
         self.locationManager.pausesLocationUpdatesAutomatically = NO;
         self.dropEmptyRanges = NO;
     }
-
+    
     return self;
 }
 
@@ -47,38 +47,38 @@ RCT_EXPORT_MODULE()
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major minor:(NSInteger) minor
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-
+    
     unsigned short mj = (unsigned short) major;
     unsigned short mi = (unsigned short) minor;
-
+    
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj minor:mi identifier:identifier];
-
+    
     beaconRegion.notifyEntryStateOnDisplay = YES;
-
+    
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-
+    
     unsigned short mj = (unsigned short) major;
-
+    
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj identifier:identifier];
-
+    
     beaconRegion.notifyEntryStateOnDisplay = YES;
-
+    
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-
+    
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID identifier:identifier];
-
+    
     beaconRegion.notifyEntryStateOnDisplay = YES;
-
+    
     return beaconRegion;
 }
 
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(stopRangingBeaconsInRegion:(NSDictionary *) dict)
 RCT_EXPORT_METHOD(startUpdatingLocation)
 {
     if ([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
-        [_locationManager setAllowsBackgroundLocationUpdates:YES];
+      [_locationManager setAllowsBackgroundLocationUpdates:YES];
     }
     [self.locationManager startUpdatingLocation];
 }
@@ -190,7 +190,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 }
 
 - (void)locationManager:(CLLocationManager *)manager rangingBeaconsDidFailForRegion:(CLBeaconRegion *)region withError:(NSError *)error
-{
+{    
     NSLog(@"Failed ranging region: %@", error);
 }
 
@@ -209,19 +209,19 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
         return;
     }
     NSMutableArray *beaconArray = [[NSMutableArray alloc] init];
-
+    
     for (CLBeacon *beacon in beacons) {
         [beaconArray addObject:@{
                                  @"uuid": [beacon.proximityUUID UUIDString],
                                  @"major": beacon.major,
                                  @"minor": beacon.minor,
-
+                                 
                                  @"rssi": [NSNumber numberWithLong:beacon.rssi],
                                  @"proximity": [self stringForProximity: beacon.proximity],
                                  @"accuracy": [NSNumber numberWithDouble: beacon.accuracy]
                                  }];
     }
-
+    
     NSDictionary *event = @{
                             @"region": @{
                                     @"identifier": region.identifier,
@@ -229,7 +229,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                                     },
                             @"beacons": beaconArray
                             };
-
+    
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"beaconsDidRange" body:event];
 }
 
@@ -239,7 +239,7 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-
+    
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidEnter" body:event];
 }
 
@@ -249,8 +249,12 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-
+    
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidExit" body:event];
+}
+
+- (void)locationManager:(CLLocationManager *)manager
+     didUpdateLocations:(NSArray<CLLocation *> *)locations {
 }
 
 @end

--- a/RNBeacon.m
+++ b/RNBeacon.m
@@ -29,16 +29,26 @@ RCT_EXPORT_MODULE()
 
 #pragma mark Initialization
 
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"authorizationStatusDidChange",
+           @"beaconsDidRange",
+           @"regionDidEnter",
+           @"regionDidExit"];
+}
+
+
+
 - (instancetype)init
 {
     if (self = [super init]) {
         self.locationManager = [[CLLocationManager alloc] init];
-        
+
         self.locationManager.delegate = self;
         self.locationManager.pausesLocationUpdatesAutomatically = NO;
         self.dropEmptyRanges = NO;
     }
-    
+
     return self;
 }
 
@@ -47,38 +57,38 @@ RCT_EXPORT_MODULE()
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major minor:(NSInteger) minor
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     unsigned short mj = (unsigned short) major;
     unsigned short mi = (unsigned short) minor;
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj minor:mi identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid major: (NSInteger) major
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     unsigned short mj = (unsigned short) major;
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID major:mj identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
 - (CLBeaconRegion *) createBeaconRegion: (NSString *) identifier uuid: (NSString *) uuid
 {
     NSUUID *beaconUUID = [[NSUUID alloc] initWithUUIDString:uuid];
-    
+
     CLBeaconRegion *beaconRegion = [[CLBeaconRegion alloc] initWithProximityUUID:beaconUUID identifier:identifier];
-    
+
     beaconRegion.notifyEntryStateOnDisplay = YES;
-    
+
     return beaconRegion;
 }
 
@@ -186,11 +196,11 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
 -(void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
     NSString *statusName = [self nameForAuthorizationStatus:status];
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"authorizationStatusDidChange" body:statusName];
+    [self sendEventWithName:@"authorizationStatusDidChange" body:statusName];
 }
 
 - (void)locationManager:(CLLocationManager *)manager rangingBeaconsDidFailForRegion:(CLBeaconRegion *)region withError:(NSError *)error
-{    
+{
     NSLog(@"Failed ranging region: %@", error);
 }
 
@@ -209,19 +219,19 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
         return;
     }
     NSMutableArray *beaconArray = [[NSMutableArray alloc] init];
-    
+
     for (CLBeacon *beacon in beacons) {
         [beaconArray addObject:@{
                                  @"uuid": [beacon.proximityUUID UUIDString],
                                  @"major": beacon.major,
                                  @"minor": beacon.minor,
-                                 
+
                                  @"rssi": [NSNumber numberWithLong:beacon.rssi],
                                  @"proximity": [self stringForProximity: beacon.proximity],
                                  @"accuracy": [NSNumber numberWithDouble: beacon.accuracy]
                                  }];
     }
-    
+
     NSDictionary *event = @{
                             @"region": @{
                                     @"identifier": region.identifier,
@@ -229,8 +239,8 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                                     },
                             @"beacons": beaconArray
                             };
-    
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"beaconsDidRange" body:event];
+
+    [self sendEventWithName:@"beaconsDidRange" body:event];
 }
 
 -(void)locationManager:(CLLocationManager *)manager
@@ -239,8 +249,8 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-    
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidEnter" body:event];
+
+    [self sendEventWithName:@"regionDidEnter" body:event];
 }
 
 -(void)locationManager:(CLLocationManager *)manager
@@ -249,8 +259,8 @@ RCT_EXPORT_METHOD(shouldDropEmptyRanges:(BOOL)drop)
                             @"region": region.identifier,
                             @"uuid": [region.proximityUUID UUIDString],
                             };
-    
-    [self.bridge.eventDispatcher sendDeviceEventWithName:@"regionDidExit" body:event];
+
+    [self sendEventWithName:@"regionDidExit" body:event];
 }
 
 - (void)locationManager:(CLLocationManager *)manager


### PR DESCRIPTION
RCTBridge.h is causing duplicate interface definition for class 'RTBridge. 
More information is shared in https://github.com/frostney/react-native-ibeacon/issues/51

The below fix should fix the issue